### PR TITLE
Control google streetview by gamepad

### DIFF
--- a/streetview.cfg
+++ b/streetview.cfg
@@ -1,0 +1,27 @@
+﻿[General]
+FileVersion=64
+NumberOfJoysticks=2
+NumberOfButtons=32
+DisplayMode=2
+UseDiagonalInput=0
+UsePOV8Way=0
+RepeatSameKeyInSequence=0
+Threshold=20
+Threshold2=20
+KeySendMode=0
+SoundFile=
+ImageFile=
+
+[Joystick 1]
+POV1-1=1, 26:00:00:00, 15.000, 0, 700
+POV1-3=1, 27:00:00:00, 0.000, 0, 0
+POV1-5=1, 28:00:00:00, 15.000, 0, 0
+POV1-7=1, 25:00:00:00, 0.000, 0, 0
+Axis3n=2,   50,   0,   0, 1, 0, 0, 0.000, 0, 95, 1.0, 100, 0, 0, 0,    0
+Axis3p=2,  -50,   0,   0, 1, 0, 0, 0.000, 0, 95, 1.0, 100, 0, 0, 0,    0
+Axis4n=2,    0,  50,   0, 1, 0, 0, 0.000, 0, 95, 1.0, 100, 0, 0, 0,    0
+Axis4p=2,    0, -50,   0, 1, 0, 0, 0.000, 0, 95, 1.0, 100, 0, 0, 0,    0
+Button01=8, 50.000000, 50.000000, 0, 0, 0, 0, 0, 0, 0, 0.000, 0, 0
+Button03=1, 6B:00:00:00, 0.000, 0, 0
+Button04=1, 6D:00:00:00, 0.000, 0, 0
+


### PR DESCRIPTION
With this config file (tested with 6.4.1) you can control the google streetview with a logitech F710 gamepad (it allows moving image panning, centering cursors and zoom in/out)